### PR TITLE
Set default to array to avoid fatal array for checkboxes

### DIFF
--- a/class-gf-user-registration.php
+++ b/class-gf-user-registration.php
@@ -1001,7 +1001,7 @@ class GF_User_Registration extends GFFeedAddOn {
 
 				case 'checkbox':
 
-					$value = rgar( $mapped_fields, $field->id );
+					$value = rgar( $mapped_fields, $field->id, array() );
 
 					if ( empty( $value ) ) {
 						$value = array();


### PR DESCRIPTION
```Fatal error
: Uncaught Error: [] operator not supported for strings in /Users/Matt/Sites/KGA Consultant Area/wp-content/plugins/gravityformsuserregistration/class-gf-user-registration.php:1009 Stack trace: #0 /Users/Matt/Sites/KGA Consultant Area/wp-content/plugins/gravityformsuserregistration/class-gf-user-registration.php(896): GF_User_Registration::prepopulate_form(Array, Array, 1) #1 /Users/Matt/Sites/KGA Consultant Area/wp-includes/class-wp-hook.php(288): GF_User_Registration::maybe_prepopulate_form(Array) #2 /Users/Matt/Sites/KGA Consultant Area/wp-includes/plugin.php(203): WP_Hook->apply_filters(Array, Array) #3 /Users/Matt/Sites/KGA Consultant Area/wp-content/plugins/gravityforms/gravityforms.php(5200): apply_filters('gform_pre_rende...', Array, true, '', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL) #4 /Users/Matt/Sites/KGA Consultant Area/wp-content/plugins/gravityforms/form_display.php(805): gf_apply_filters('gform_pre_rende...', Array, true, '') #5 /Users/Matt/Sites/KGA Consultant Area/wp-content/plugins/grav in
/Users/Matt/Sites/KGA Consultant Area/wp-content/plugins/gravityformsuserregistration/class-gf-user-registration.php
on line
1009```